### PR TITLE
fix import of parse_requirements for pip v10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,10 @@ See LICENCE.txt for licensing and contact information.
 """
 
 from distutils.core import setup
-from pip.req import parse_requirements
+try: # for pip >= 10
+    from pip._internal.req import parse_requirements
+except ImportError: # for pip <= 9.0.3
+    from pip.req import parse_requirements
 from runpy import run_path
 
 install_reqs = parse_requirements('requirements.txt', session=False)


### PR DESCRIPTION
Fix mattloper/chumpy#20

currently with the latest pip, setup fails with "ImportError: No module named req"
This fix is via: https://stackoverflow.com/questions/25192794/no-module-named-pip-req